### PR TITLE
Handle .dk TLD by specifying 'whois.dk-hostmaster.dk' WhoisServer

### DIFF
--- a/Network/Whois.hs
+++ b/Network/Whois.hs
@@ -52,6 +52,7 @@ serverFor a
       "io" -> server "io.whois-servers.net" defaultQuery -- answers directly
       "de" -> server "whois.denic.de" "-T dn,ace "
       "so" -> server "whois.nic.so" defaultQuery
+      "dk" -> server "whois.dk-hostmaster.dk" defaultQuery
       _    -> server (tld  ++ ".whois-servers.net") "domain "
     server h q = Just (WhoisServer h defaultPort q)
 

--- a/whois.cabal
+++ b/whois.cabal
@@ -1,5 +1,5 @@
 name:                whois
-version:             1.2.2
+version:             1.2.3
 synopsis:            WHOIS client library.
 homepage:            http://github.com/relrod/whois-hs
 bug-reports:         https://github.com/relrod/whois-hs/issues


### PR DESCRIPTION
Hi Rick

Thanks for making this package available!

I'm toying around with an anti-domain-phishing web service that uses WHOIS on domain names that sound similar to one's own. Such a service probably already exists, but I thought it'd be a fun side project. So I found your 'whois' package and realize it's a bit outdated. It still works, though, with a few warnings!

I just needed to patch it for the 'dk' ccTLD.

Bump package version from 1.2.2 to 1.2.3.

I don't think this PR warrants releasing a new package onto Hackage yet.

I have some other ideas for improvement, including a move to the non-deprecated Network API, better TLD support and some CI that tests that particular WHOIS servers are still responsive. I'd like to take things at a slow pace, though, and am just airing this to you in case you're interested in eventually bumping this package a bit.